### PR TITLE
Add server for image uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "start": "node server.js"
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,56 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, 'dist');
+const uploadDir = path.join(__dirname, 'public', 'uploads');
+fs.mkdirSync(uploadDir, { recursive: true });
+
+function serveStaticFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+    } else {
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/upload') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        const { filename, data } = JSON.parse(body);
+        const base64 = data.replace(/^data:image\/\w+;base64,/, '');
+        const buffer = Buffer.from(base64, 'base64');
+        const name = Date.now() + '-' + filename;
+        fs.writeFile(path.join(uploadDir, name), buffer, err => {
+          if (err) {
+            res.statusCode = 500;
+            return res.end('Error saving file');
+          }
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ url: `/uploads/${name}` }));
+        });
+      } catch (e) {
+        res.statusCode = 400;
+        res.end('Invalid data');
+      }
+    });
+  } else if (req.url.startsWith('/uploads/')) {
+    const filePath = path.join(__dirname, 'public', req.url);
+    serveStaticFile(res, filePath);
+  } else {
+    const file = req.url === '/' ? 'index.html' : req.url;
+    const filePath = path.join(distDir, file);
+    serveStaticFile(res, filePath);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -17,13 +17,21 @@ export default {
     handleFileChange(event) {
       const file = event.target.files[0];
       if (file) {
-        this.loadImage(file);
+        this.uploadImage(file);
       }
     },
-    loadImage(file) {
+    uploadImage(file) {
       const reader = new FileReader();
       reader.onload = event => {
-        this.imageSrc = event.target.result;
+        const dataUrl = event.target.result;
+        fetch('/upload', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filename: file.name, data: dataUrl })
+        })
+          .then(r => r.json())
+          .then(d => { this.imageSrc = d.url; })
+          .catch(err => console.error(err));
       };
       reader.readAsDataURL(file);
     },


### PR DESCRIPTION
## Summary
- add Node server to handle image uploads
- save uploaded images under `public/uploads`
- update ImageLoader component to send images to server
- start the server via `pnpm run start`

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f5b9c20ac832b9bc67e1614c2d359